### PR TITLE
Log warnings when interpolated variable is not found

### DIFF
--- a/eastern/yaml_formatter/formatter.py
+++ b/eastern/yaml_formatter/formatter.py
@@ -44,10 +44,15 @@ class Formatter(BaseFormatter):
         return self.body
 
     def interpolate_env(self, text):
-        for key, value in self.env.items():
-            text = text.replace("${" + key + "}", value)
+        return re.sub(r'\${([^}]+)}', self.replace_env, text)
 
-        return text
+    def replace_env(self, match):
+        key = match.group(1)
+        if key in self.env:
+            return self.env[key]
+        else:
+            # warn here
+            self.logger.debug('Variable not found: %s', key, exc_info=True)
 
     def parse_lines(self, body):
         body_lines = body.split(os.linesep)

--- a/eastern/yaml_formatter/formatter.py
+++ b/eastern/yaml_formatter/formatter.py
@@ -51,8 +51,8 @@ class Formatter(BaseFormatter):
         if key in self.env:
             return self.env[key]
         else:
-            # warn here
-            self.logger.debug('Variable not found: %s', key, exc_info=True)
+            self.logger.warning('Interpolated variable not found: %s', key)
+            return match.group()
 
     def parse_lines(self, body):
         body_lines = body.split(os.linesep)


### PR DESCRIPTION
The current implementation matches and replaces interpolations with pattern `/\${([^}]+)}/`.
This can be changed if a different behavior is desired.

This should resolve #3.