### PR TITLE
always clean job and watch status properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build
 .cache
 .eggs
 .pytest_cache
+__pycache__
+dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [4.1.0] - 2018-07-06
+### Changed
+- Job deployment will always removed after job success or failed
+- Fix exception raised when deploy job but pod was not scheduled
+
 ## [4.0.0] - 2018-06-15
 ### Added
 - Pluggable formatters

--- a/eastern/job_manager.py
+++ b/eastern/job_manager.py
@@ -1,0 +1,123 @@
+import time
+
+from .timeout import ProcessTimeout
+
+
+class JobManager(object):
+    def __init__(self, kubectl, job_name):
+        self.kubectl = kubectl
+        self.job_name = job_name
+
+    def is_pod_scheduled(self):
+        """
+        Check is job pod was scheduled by looking at number of job active, succeeded and failed
+
+        :rtype: bool
+        """
+        status = self.kubectl.get_job_status(self.job_name)
+        return status.active + status.failed + status.succeeded > 0
+
+    def wait_pod_scheduled(self, timeout_second=10):
+        """
+        Check every 1 second to see if pod was scheduled, you can specify maximum timeout in second
+
+        :param timeout_second int: time to wait in seconds, default is to wait for 10 seconds
+        :raises: JobTimedOutException in case that pod was not scheduled and over time limit
+        """
+        if not timeout_second:
+            timeout_second = 10
+
+        try:
+            retry(lambda: self.is_pod_scheduled(), count=timeout_second)
+        except RetryLimitReach:
+            raise JobTimedOutException("pod not scheduled in time")
+
+    def is_completed(self):
+        """
+        Check if job was completed and was not care whether a job was succeeded or failed.
+
+        :rtype: bool
+        """
+        status = self.kubectl.get_job_status(self.job_name)
+        return (status.failed + status.succeeded > 0) and status.active == 0
+
+    def wait_completion(self, idle_timeout=None):
+        """
+        Wait until job was completed.
+
+        :param idle_timeout int: time to wait in seconds
+        """
+        if not self.is_pod_scheduled():
+            raise JobOperationException(
+                "Wait for completion must run after pod was scheduled")
+
+        pod_names = self.get_pod_names()
+        for pod_name in pod_names:
+            if self.is_completed():
+                return
+
+            # wait for pod phrase to ready to be logged
+            retry(lambda: is_pod_phrase_can_get_log(
+                self.kubectl.get_pod_phase(pod_name)))
+
+            args = self.kubectl.get_launch_args() + ['logs', '-f', pod_name]
+            ProcessTimeout(idle_timeout, *args).run_sync()
+
+    def get_pod_name(self):
+        """
+        Get pod name, if there are multiple pods, return the first one (lexicological sort)
+
+        :rtype: str
+        :raises JobNotFound: If no pod for that job is found
+        """
+        return self.get_pod_names()[0]
+
+    def get_pod_names(self):
+        """
+        Get pod names, ordered by lexicological
+
+        :rtype: list
+        :raises JobNotFound: If no pod for that job is found
+        """
+        names_str = self.kubectl.get_job_pod_name(self.job_name)
+        names = names_str.split()
+        names.sort()
+        return names
+
+    def remove(self):
+        """
+        Delete job
+
+        :raises JobOperationException: if delete job exit code was not 0 (succeeded)
+        """
+        exit_code = self.kubectl.delete_job(self.job_name)
+        if exit_code != 0:
+            raise JobOperationException(
+                "remove job {name} failed, exit code {exit_code}".format(name=self.job_name, exit_code=exit_code))
+
+
+def retry(bool_fn, count=10, interval=1):
+    while count > 0:
+        result = bool_fn()
+        if result:
+            return
+        count = count - 1
+        time.sleep(interval)  # second to sleep
+    raise RetryLimitReach()
+
+
+def is_pod_phrase_can_get_log(phrase):
+    print("Pod phrase: ", phrase)
+    return phrase and phrase.lower() in ["running", "succeeded", "failed"]
+
+
+class JobOperationException(Exception):
+    pass
+
+
+class JobTimedOutException(Exception):
+    pass
+
+
+class RetryLimitReach(Exception):
+    pass

--- a/eastern/kubectl.py
+++ b/eastern/kubectl.py
@@ -23,7 +23,7 @@ class Kubectl:
         Get kubectl command line
 
         eg. ``['kubectl', '--namespace', 'production', '--context', 'production']``
-        
+
         :rtype: list[str]
         """
         out = [self.path]
@@ -136,6 +136,41 @@ class Kubectl:
             name,
         ])
 
+    def get_job_status(self, name):
+        """
+        Get Job status
+
+        :param str name: Job name
+        :rtype: JobStatus
+        :raises: KeyError in case there is no status in response
+        """
+        job = subprocess.check_output(
+            self.get_launch_args() + ['get', 'job', name, '-o', 'json'])
+        return JobStatus(json.loads(job)['status'])
+
+
+class JobStatus(object):
+    def __init__(self, json_dict):
+        self.json_dict = json_dict
+
+    @property
+    def succeeded(self):
+        if 'succeeded' in self.json_dict:
+            return self.json_dict['succeeded']
+        return 0
+
+    @property
+    def active(self):
+        if 'active' in self.json_dict:
+            return self.json_dict['active']
+        return 0
+
+    @property
+    def failed(self):
+        if 'failed' in self.json_dict:
+            return self.json_dict['failed']
+        return 0
+
 
 class KubernetesException(Exception):
     pass
@@ -144,7 +179,7 @@ class KubernetesException(Exception):
 class JobNotFound(KubernetesException):
     """
     Cannot find the given job
-    
+
     Raised by :py:func:`Kubectl.get_job_pod_name`
     """
     pass

--- a/eastern/kubectl.py
+++ b/eastern/kubectl.py
@@ -155,21 +155,15 @@ class JobStatus(object):
 
     @property
     def succeeded(self):
-        if 'succeeded' in self.json_dict:
-            return self.json_dict['succeeded']
-        return 0
+        return self.json_dict.get('succeeded', 0)
 
     @property
     def active(self):
-        if 'active' in self.json_dict:
-            return self.json_dict['active']
-        return 0
+        return self.json_dict.get('active', 0)
 
     @property
     def failed(self):
-        if 'failed' in self.json_dict:
-            return self.json_dict['failed']
-        return 0
+        return self.json_dict.get('failed', 0)
 
 
 class KubernetesException(Exception):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='eastern',
     description='Simple Kubernetes Deployment',
-    version='4.0.0',
+    version='4.1.0',
     packages=find_packages(),
     url='https://github.com/wongnai/eastern',
     install_requires=[

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -13,19 +13,16 @@ def kubectl():
     return MagicMock(Kubectl)
 
 def test_get_pod_names(kubectl):
-    kubectl = MagicMock(Kubectl)
     kubectl.get_job_pod_name.return_value = MULTI_POD_NAMES
     job_manager = JobManager(kubectl, JOB_NAME)
     assert job_manager.get_pod_names() == ["test-job-2abcd", "test-job-9vmlg"]
 
 def test_get_pod_names_with_single_pod(kubectl):
-    kubectl = MagicMock(Kubectl)
     kubectl.get_job_pod_name.return_value = SINGLE_POD_NAMES
     job_manager = JobManager(kubectl, JOB_NAME)
     assert job_manager.get_pod_names() == ["test-job-9vmlg"]
 
 def test_get_pod_name(kubectl):
-    kubectl = MagicMock(Kubectl)
     kubectl.get_job_pod_name.return_value = MULTI_POD_NAMES
     job_manager = JobManager(kubectl, JOB_NAME)
     assert job_manager.get_pod_name() == "test-job-2abcd"

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -1,0 +1,31 @@
+import pytest
+
+from eastern.job_manager import JobManager
+from eastern import Kubectl
+from unittest.mock import MagicMock
+
+JOB_NAME = "test-job"
+MULTI_POD_NAMES = "test-job-9vmlg test-job-2abcd"
+SINGLE_POD_NAMES = "test-job-9vmlg"
+
+@pytest.fixture
+def kubectl():
+    return MagicMock(Kubectl)
+
+def test_get_pod_names(kubectl):
+    kubectl = MagicMock(Kubectl)
+    kubectl.get_job_pod_name.return_value = MULTI_POD_NAMES
+    job_manager = JobManager(kubectl, JOB_NAME)
+    assert job_manager.get_pod_names() == ["test-job-2abcd", "test-job-9vmlg"]
+
+def test_get_pod_names_with_single_pod(kubectl):
+    kubectl = MagicMock(Kubectl)
+    kubectl.get_job_pod_name.return_value = SINGLE_POD_NAMES
+    job_manager = JobManager(kubectl, JOB_NAME)
+    assert job_manager.get_pod_names() == ["test-job-9vmlg"]
+
+def test_get_pod_name(kubectl):
+    kubectl = MagicMock(Kubectl)
+    kubectl.get_job_pod_name.return_value = MULTI_POD_NAMES
+    job_manager = JobManager(kubectl, JOB_NAME)
+    assert job_manager.get_pod_name() == "test-job-2abcd"

--- a/tests/test_kubectl.py
+++ b/tests/test_kubectl.py
@@ -3,45 +3,44 @@ import pytest
 from eastern import Kubectl
 from unittest.mock import MagicMock, patch
 
-@pytest.fixture
-def job_response():
-    return """
-    {
-        "status": {
-            "completionTime": "2018-07-04T10:31:35Z",
-            "conditions": [
-                {
-                    "lastProbeTime": "2018-07-04T10:31:35Z",
-                    "lastTransitionTime": "2018-07-04T10:31:35Z",
-                    "status": "True",
-                    "type": "Complete"
-                }
-            ],
-            "startTime": "2018-07-04T10:31:23Z",
-            "succeeded": 1
-        }
+JOB_RESPONSE = """
+{
+    "status": {
+        "completionTime": "2018-07-04T10:31:35Z",
+        "conditions": [
+            {
+                "lastProbeTime": "2018-07-04T10:31:35Z",
+                "lastTransitionTime": "2018-07-04T10:31:35Z",
+                "status": "True",
+                "type": "Complete"
+            }
+        ],
+        "startTime": "2018-07-04T10:31:23Z",
+        "succeeded": 1
     }
-    """
+}
+"""
 
-@pytest.fixture
-def no_status_job_response():
-    return '{}'
+NO_STATUS_JOB_RESPONSE = '{}'
+
 
 @patch('subprocess.check_output')
-def test_get_job_status(check_output, job_response):
-    check_output.return_value = job_response
+def test_get_job_status(check_output):
+    check_output.return_value = JOB_RESPONSE
     kubectl = Kubectl()
     status = kubectl.get_job_status("test-job")
 
-    check_output.assert_called_with(['kubectl', 'get', 'job', 'test-job', '-o', 'json'])
+    check_output.assert_called_with(
+        ['kubectl', 'get', 'job', 'test-job', '-o', 'json'])
 
     assert status.succeeded == 1
     assert status.active == 0
     assert status.failed == 0
 
+
 @patch('subprocess.check_output')
-def test_get_job_status_failed(check_output, no_status_job_response):
-    check_output.return_value = no_status_job_response
+def test_get_job_status_failed(check_output):
+    check_output.return_value = NO_STATUS_JOB_RESPONSE
     kubectl = Kubectl()
 
     with pytest.raises(KeyError):

--- a/tests/test_kubectl.py
+++ b/tests/test_kubectl.py
@@ -1,0 +1,48 @@
+import pytest
+
+from eastern import Kubectl
+from unittest.mock import MagicMock, patch
+
+@pytest.fixture
+def job_response():
+    return """
+    {
+        "status": {
+            "completionTime": "2018-07-04T10:31:35Z",
+            "conditions": [
+                {
+                    "lastProbeTime": "2018-07-04T10:31:35Z",
+                    "lastTransitionTime": "2018-07-04T10:31:35Z",
+                    "status": "True",
+                    "type": "Complete"
+                }
+            ],
+            "startTime": "2018-07-04T10:31:23Z",
+            "succeeded": 1
+        }
+    }
+    """
+
+@pytest.fixture
+def no_status_job_response():
+    return '{}'
+
+@patch('subprocess.check_output')
+def test_get_job_status(check_output, job_response):
+    check_output.return_value = job_response
+    kubectl = Kubectl()
+    status = kubectl.get_job_status("test-job")
+
+    check_output.assert_called_with(['kubectl', 'get', 'job', 'test-job', '-o', 'json'])
+
+    assert status.succeeded == 1
+    assert status.active == 0
+    assert status.failed == 0
+
+@patch('subprocess.check_output')
+def test_get_job_status_failed(check_output, no_status_job_response):
+    check_output.return_value = no_status_job_response
+    kubectl = Kubectl()
+
+    with pytest.raises(KeyError):
+        kubectl.get_job_status("test-job")


### PR DESCRIPTION
There was a case that pod was not scheduled but job trying to get pod name.

kubectl raise an exception in this case, so it makes eastern exit unclean and leaves Kubernetes job there.

This PR try to handle these cases and provide JobManager API to make the code more organized.