### PR TITLE
Wait for job completion after reading all logs

### DIFF
--- a/eastern/job_manager.py
+++ b/eastern/job_manager.py
@@ -74,6 +74,8 @@ class JobManager(object):
 
             args = self.kubectl.get_launch_args() + ["logs", "-f", pod_name]
             ProcessTimeout(idle_timeout, *args).run_sync()
+            # wait for job completion
+            retry(lambda: self.is_completed(), count=10)
 
     def get_pod_name(self):
         """

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -1,8 +1,10 @@
 import pytest
 
 from eastern.job_manager import JobManager
+from eastern.kubectl import JobStatus
+from eastern.timeout import ProcessTimeout
 from eastern import Kubectl
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 JOB_NAME = "test-job"
 MULTI_POD_NAMES = "test-job-9vmlg test-job-2abcd"
@@ -12,7 +14,6 @@ SINGLE_POD_NAMES = "test-job-9vmlg"
 @pytest.fixture
 def kubectl():
     return MagicMock(Kubectl)
-
 
 def test_get_pod_names(kubectl):
     kubectl.get_job_pod_name.return_value = MULTI_POD_NAMES
@@ -30,3 +31,24 @@ def test_get_pod_name(kubectl):
     kubectl.get_job_pod_name.return_value = MULTI_POD_NAMES
     job_manager = JobManager(kubectl, JOB_NAME)
     assert job_manager.get_pod_name() == "test-job-2abcd"
+
+
+def test_wait_completion_success(kubectl):
+    kubectl.get_job_pod_name.return_value = JOB_NAME
+    kubectl.get_pod_phase.return_value = 'RUNNING'
+    job_manager = JobManager(kubectl, JOB_NAME)
+    kubectl.get_job_status.return_value = JobStatus({"active" : 0, "succeeded" : 1})
+    job_manager.wait_completion()
+
+
+@patch.object(ProcessTimeout, 'run_sync', MagicMock(return_value=None))
+def test_wait_completion(kubectl): 
+    kubectl.get_job_pod_name.return_value = JOB_NAME
+    kubectl.get_pod_phase.return_value = 'RUNNING'
+
+    job_manager = JobManager(kubectl, JOB_NAME)
+    kubectl.get_job_status.side_effect = [ JobStatus({"active" : 1}), JobStatus({"active" : 1}), JobStatus({"active" : 0, "succeeded": 1}) ]
+    
+    job_manager.wait_completion()
+
+


### PR DESCRIPTION
Running kubernetes job sometimes failed since the job status was still active after reading all logs from pod.

Here is the logs I got from running eastern. The job actually returned 0 but eastern script just check kube job and it was still active.

```
2020-08-17 12:45:47.154  INFO 7 --- [           main] c.w.d.c.c.Application                    : Started Application in 7.687 seconds (JVM running for 8.732)
Finished running db-changelog with exit code 0
failed=0 succeeded=0 active=1
failed=0 succeeded=0 active=1
failed=0 succeeded=1 active=0
```

To fix the issue, just wait for job completion status in wati_completion().